### PR TITLE
Unification of the brand api

### DIFF
--- a/lib/catalog/brand-api.d.ts
+++ b/lib/catalog/brand-api.d.ts
@@ -9,6 +9,6 @@ export declare class BrandApi {
     createBrand<T extends brand_Post, R extends brand_Full>(brand: T): Promise<Data<R>>;
     deleteBrands<Params extends DeleteBrandsQueryParams>(params?: Params): Promise<void>;
     getBrand<T extends brand_Full, Params extends FieldAwareQueryParams>(brandId: number, params?: Params): Promise<Data<T>>;
-    updateBrand<T extends brand_Put, R extends brand_Full>(brand: T): Promise<Data<R>>;
+    updateBrand<T extends brand_Put, R extends brand_Full>(brandId: number, brand: T): Promise<Data<R>>;
     deleteBrand(brandId: number): Promise<void>;
 }

--- a/lib/catalog/brand-api.js
+++ b/lib/catalog/brand-api.js
@@ -38,9 +38,9 @@ class BrandApi {
             return response.data;
         });
     }
-    updateBrand(brand) {
+    updateBrand(brandId, brand) {
         return __awaiter(this, void 0, void 0, function* () {
-            const response = yield this.apiClient.put(`/v3/catalog/brands/${brand.id}`, brand);
+            const response = yield this.apiClient.put(`/v3/catalog/brands/${brandId}`, brand);
             return response.data;
         });
     }

--- a/lib/model/generated/catalog.v3/models/brand_Put.d.ts
+++ b/lib/model/generated/catalog.v3/models/brand_Put.d.ts
@@ -3,10 +3,6 @@
  */
 export type brand_Put = {
     /**
-     * Unique ID of the *Brand*. Read-Only.
-     */
-    readonly id?: number;
-    /**
      * The name of the brand. Must be unique.
      * Required in POST.
      */

--- a/src/catalog/brand-api.ts
+++ b/src/catalog/brand-api.ts
@@ -46,9 +46,9 @@ export class BrandApi {
         return response.data;
     }
 
-    async updateBrand<T extends brand_Put, R extends brand_Full>(brand: T): Promise<Data<R>> {
+    async updateBrand<T extends brand_Put, R extends brand_Full>(brandId: number, brand: T): Promise<Data<R>> {
         const response = await this.apiClient.put(
-            `/v3/catalog/brands/${brand.id}`,
+            `/v3/catalog/brands/${brandId}`,
             brand
         );
         return response.data;

--- a/src/model/generated/catalog.v3/models/brand_Put.ts
+++ b/src/model/generated/catalog.v3/models/brand_Put.ts
@@ -7,10 +7,6 @@
  */
 export type brand_Put = {
     /**
-     * Unique ID of the *Brand*. Read-Only.
-     */
-    readonly id?: number;
-    /**
      * The name of the brand. Must be unique.
      * Required in POST.
      */


### PR DESCRIPTION
- Removed ID from `brand_Put` (readonly field does't make sense)
- Changed `updateBrand(brand: brand_Put)` to `updateBrand(brandId: number, brand: brand_Put)` to match the style of the other endpoints