### PR TITLE
A bit of unification in `.catalog.category.updateCategory`

### DIFF
--- a/lib/catalog/category-api.d.ts
+++ b/lib/catalog/category-api.d.ts
@@ -9,6 +9,6 @@ export declare class CategoryApi {
     createCategory<T extends category_Post, R extends category_Full>(category: T): Promise<Data<R>>;
     deleteCategories<Params extends CategoriesQueryParams>(params?: Params): Promise<void>;
     getCategory<Params extends FieldAwareQueryParams, T extends category_Full>(categoryId: number, params?: Params): Promise<Data<T>>;
-    updateCategory<T extends category_Put, R extends category_Full>(category: T): Promise<Data<R>>;
+    updateCategory<T extends category_Put, R extends category_Full>(categoryId: number, category: T): Promise<Data<R>>;
     deleteCategory(categoryId: number): Promise<void>;
 }

--- a/lib/catalog/category-api.js
+++ b/lib/catalog/category-api.js
@@ -38,9 +38,9 @@ class CategoryApi {
             return response.data;
         });
     }
-    updateCategory(category) {
+    updateCategory(categoryId, category) {
         return __awaiter(this, void 0, void 0, function* () {
-            const response = yield this.apiClient.put(`/v3/catalog/categories/${category.id}`, category);
+            const response = yield this.apiClient.put(`/v3/catalog/categories/${categoryId}`, category);
             return response.data;
         });
     }

--- a/lib/model/generated/catalog.v3/models/category_Put.d.ts
+++ b/lib/model/generated/catalog.v3/models/category_Put.d.ts
@@ -3,11 +3,6 @@
  */
 export type category_Put = {
     /**
-     * Unique ID of the *Category*. Increments sequentially.
-     * Read-Only.
-     */
-    readonly id?: number;
-    /**
      * The unique numeric ID of the category's parent. This field controls where the category sits in the tree of categories that organize the catalog.
      * Required in a POST if creating a child category.
      */

--- a/src/catalog/category-api.ts
+++ b/src/catalog/category-api.ts
@@ -5,7 +5,7 @@ import { appendQueryString } from "../util";
 import { Category, category_Post, category_Put, category_Full } from "../model/generated/catalog.v3";
 
 export class CategoryApi {
-    constructor(private readonly apiClient: ApiClient) {}
+    constructor(private readonly apiClient: ApiClient) { }
 
     async getAllCategories<
         Params extends CategoriesQueryParams,
@@ -49,9 +49,9 @@ export class CategoryApi {
         return response.data;
     }
 
-    async updateCategory<T extends category_Put, R extends category_Full>(category: T): Promise<Data<R>> {
+    async updateCategory<T extends category_Put, R extends category_Full>(categoryId: number, category: T): Promise<Data<R>> {
         const response = await this.apiClient.put(
-            `/v3/catalog/categories/${category.id}`,
+            `/v3/catalog/categories/${categoryId}`,
             category
         );
         return response.data;

--- a/src/model/generated/catalog.v3/models/category_Put.ts
+++ b/src/model/generated/catalog.v3/models/category_Put.ts
@@ -7,11 +7,6 @@
  */
 export type category_Put = {
     /**
-     * Unique ID of the *Category*. Increments sequentially.
-     * Read-Only.
-     */
-    readonly id?: number;
-    /**
      * The unique numeric ID of the category's parent. This field controls where the category sits in the tree of categories that organize the catalog.
      * Required in a POST if creating a child category.
      */


### PR DESCRIPTION
- Removed ID from `category_Put` (readonly field does't make sense)
- Changed `updateCategory(category: category_Put)` to `updateBrand(categoryId: number, category: category_Put)` to match the style of the other endpoints